### PR TITLE
Messages in channels with little to no messages will now start at the bottom

### DIFF
--- a/src/webpage/style.css
+++ b/src/webpage/style.css
@@ -1441,6 +1441,7 @@ span.instanceStatus {
 	max-height: fit-content;
 	flex-basis: auto;
 	flex-grow: 0;
+	margin-top: auto;
 }
 .scroller {
 	flex: 1;
@@ -1462,7 +1463,6 @@ span.instanceStatus {
 }
 #ghostMessages {
 	transform: translate(0px, -22px);
-	flex-grow: 1;
 }
 #pasteimage:empty {
 	height: 0;
@@ -1627,6 +1627,9 @@ span.instanceStatus {
 .titlespace {
 	padding: 3px 36px 3px 16px;
 	border-left: 2px solid transparent;
+}
+.titlespace {
+	margin-bottom: 20px;
 }
 .messagediv {
 	position: relative;


### PR DESCRIPTION
# Description
- #ghostMessages no longer has flex-grow, it was there so the input text area wouldn't go to the top
- #channelw now has margin-top: auto to force messages to the bottom, shouldn't break scroller, also forces input text area to the bottom
- .titlespace has a small margin at the bottom so it's not directly next to the input text area

Should work fine, scrolling isn't broken. Only issue I encountered was messages sometimes disappearing and appearing out of thin air after sending them, though that might be a spacebar thing.